### PR TITLE
[HELM]: Move CRD resources to a separate folder as per helm standard

### DIFF
--- a/charts/aws-vpc-cni/README.md
+++ b/charts/aws-vpc-cni/README.md
@@ -81,7 +81,7 @@ $ helm install --name aws-vpc-cni --namespace kube-system eks/aws-vpc-cni --valu
 
 ## Adopting the existing aws-node resources in an EKS cluster
 
-If you do not want to delete the existing aws-node resources in your cluster that run the aws-vpc-cni and then install this helm chart, you can adopt the resources into a release instead. This process is highlighted in this [PR comment](https://github.com/aws/eks-charts/issues/57#issuecomment-628403245). Once you have annotated and labeled all the resources this chart specifies, enable the `originalMatchLabels` flag, and also set `crd.create` to false on the helm release and run an update. If you have been careful this should not diff and leave all the resources unmodified and now under management of helm.
+If you do not want to delete the existing aws-node resources in your cluster that run the aws-vpc-cni and then install this helm chart, you can adopt the resources into a release instead. This process is highlighted in this [PR comment](https://github.com/aws/eks-charts/issues/57#issuecomment-628403245). Once you have annotated and labeled all the resources this chart specifies, enable the `originalMatchLabels` flag. If you have been careful this should not diff and leave all the resources unmodified and now under management of helm.
 
 Here is an example script to modify the existing resources:
 

--- a/charts/aws-vpc-cni/crds/customresourcedefinition.yaml
+++ b/charts/aws-vpc-cni/crds/customresourcedefinition.yaml
@@ -1,10 +1,9 @@
-{{- if .Values.crd.create -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: eniconfigs.crd.k8s.amazonaws.com
   labels:
-{{ include "aws-vpc-cni.labels" . | indent 4 }}
+    k8s-app: aws-node
 spec:
   scope: Cluster
   group: crd.k8s.amazonaws.com
@@ -21,4 +20,3 @@ spec:
     plural: eniconfigs
     singular: eniconfig
     kind: ENIConfig
-{{- end -}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?** cleanup

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:  https://github.com/aws/amazon-vpc-cni-k8s/issues/2075


**What does this PR do / Why do we need it**: Standardize folders as per Helm 


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**: Yes
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:  N/A
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this PR introduce any new dependencies?**: No
<!-- 
e.g. new EC2/K8s API, IMDS API, dependency on specific kernel module/version or binary in container OS.
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**: Yes


**Does this change require updates to the CNI daemonset config files to work?**: No
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**: Yes
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
* Moved CRDs for `amazon-vpc-cni-k8s` chart to a dedicated folder as per helm standard
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
